### PR TITLE
dotenv rails to secure secret key before installing cloudinary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "simple_form", github: "heartcombo/simple_form"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  gem "dotenv-rails"
+  gem "dotenv-rails", groups: [:development, :test]
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
@@ -249,6 +251,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 


### PR DESCRIPTION
install dotenv rails to secure secret keys for cloudinary